### PR TITLE
Bugfix for issue #12

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ function previewLine(event) {
 }
 
 function int(n) {
-    return typeof n === 'number';
+    return !Number.isNaN(+n);
 }
 
 function copyText() {
@@ -75,7 +75,7 @@ function drawLines() {
     ctx.beginPath()
     ctx.strokeStyle = '#000000';
     ctx.lineWidth = 1;
-
+    console.log(JSON.stringify(canvasArray));
     while (i < canvasArray.length) {
         let CA1 = canvasArray[i];
         let CA2 = canvasArray[i + 1];
@@ -92,9 +92,10 @@ function drawLines() {
                 ctx.beginPath();
                 ctx.strokeStyle = CA1;
                 ctx.lineWidth = CA2;
+                console.log(i, CA1, CA2);
                 i += 2;
             } else {
-                if (Math.sign(CA1)) {
+                if (int(CA1) && Math.sign(CA1)) {
                     // line width
                     ctx.stroke();
                     ctx.beginPath();
@@ -237,6 +238,7 @@ canvas.addEventListener('pointerdown', (e) => {
         canvasArray[num] = x;
         num++;
         canvasArray[num] = y;
+        console.log(JSON.stringify(canvasArray));
         canvas.addEventListener('pointermove', previewLineHandler);
     }
 
@@ -289,6 +291,8 @@ reset.addEventListener('click', () => {
     canvasArray = [];
     num = -1;
     localStorage.removeItem('canvasArray');
+    stroke = 1;
+    color = '#000000';
     setArray();
 });
 

--- a/script.js
+++ b/script.js
@@ -81,23 +81,27 @@ function drawLines() {
         let CA2 = canvasArray[i + 1];
 
         if (int(CA1) && int(CA2)) {
+            // coordinates of points
             ctx.moveTo(CA1, CA2);
             ctx.lineTo(canvasArray[i + 2], canvasArray[i + 3]);
             i += 4;
         } else {
-            if (!(int(CA1) || int(CA2))) {
+            if (!int(CA1) && int(CA2)) {
+                // Line color and line width
                 ctx.stroke();
                 ctx.beginPath();
                 ctx.strokeStyle = CA1;
-                ctx.lineWidth = CA1 || "#000";
+                ctx.lineWidth = CA2;
                 i += 2;
             } else {
                 if (Math.sign(CA1)) {
+                    // line width
                     ctx.stroke();
                     ctx.beginPath();
                     ctx.lineWidth = CA1;
                     i++;
                 } else {
+                    // line color
                     ctx.stroke();
                     ctx.beginPath();
                     ctx.strokeStyle = CA1 || "#000";
@@ -214,7 +218,6 @@ canvas.addEventListener('pointerdown', (e) => {
     const localStroke = document.querySelector('.stroke-width').value || 1;
     if (localStroke !== '0') {
         const localColor = document.querySelector('.color').value;
-
         if (localColor !== color) {
             color = localColor;
             num++;
@@ -234,7 +237,6 @@ canvas.addEventListener('pointerdown', (e) => {
         canvasArray[num] = x;
         num++;
         canvasArray[num] = y;
-
         canvas.addEventListener('pointermove', previewLineHandler);
     }
 
@@ -287,8 +289,6 @@ reset.addEventListener('click', () => {
     canvasArray = [];
     num = -1;
     localStorage.removeItem('canvasArray');
-    stroke = 1;
-    color = '#000000';
     setArray();
 });
 


### PR DESCRIPTION
- The line width was reset because it was set incorrectly in drawLines(). A hex code was being set as line width
- Additionally, added a cleaner way to check if given variable is a number. The old implementation of int() does not work on lineWidth values stored in canvasArray, as they are of type 'string'