### PR TITLE
Bug fix for issue #12

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,7 +89,7 @@ function drawLines() {
                 ctx.stroke();
                 ctx.beginPath();
                 ctx.strokeStyle = CA1;
-                ctx.lineWidth = CA1;
+                ctx.lineWidth = +CA2;
                 i += 2;
             } else {
                 if (Math.sign(CA1)) {


### PR DESCRIPTION
`HTMLCanvas2DContext` has a property called `lineWidth` which expects a numeric value. But, in `drawLines`, it was being set with a hex code which causes the undefined behaviour. Attached clip demonstrating fix

https://github.com/user-attachments/assets/3819887d-c3f4-419a-b083-d4768d9bd801

